### PR TITLE
Disable -O3 due to emscripten issue 2542

### DIFF
--- a/travis/xenial-emscripten/build.sh
+++ b/travis/xenial-emscripten/build.sh
@@ -27,7 +27,8 @@ echo "Building..."
 emmake make
 
 echo "Emscripten Binding/Optimizing..."
-emcc --bind libjsqrl.so -O3 -o libjsqrl.js
+#FIXME: Disable .mem for node.js until this gets fixed: https://github.com/kripken/emscripten/issues/2542
+emcc --bind libjsqrl.so -O2 -o libjsqrl.js
 emcc --bind libjsqrl.so -O3 -s WASM=1 -o web-libjsqrl.js
 
 


### PR DESCRIPTION
Moving to -O2 until https://github.com/kripken/emscripten/issues/2542 is fixed