### PR TITLE
Add single file output from emscripten to build

### DIFF
--- a/.circleci/build_emscripten.sh
+++ b/.circleci/build_emscripten.sh
@@ -6,7 +6,9 @@ emmake make
 # FIXME: Disable .mem for node.js until this gets fixed: https://github.com/kripken/emscripten/issues/2542
 emcc --bind libjsqrl.so -s DISABLE_EXCEPTION_CATCHING=0 -O3 --memory-init-file 0  -o libjsqrl.js
 emcc --bind libjsqrl.so -s DISABLE_EXCEPTION_CATCHING=0 -O3 -s WASM=1 -o web-libjsqrl.js
+emcc --bind libjsqrl.so -s DISABLE_EXCEPTION_CATCHING=0 -O3 -s WASM=1 -s -s SINGLE_FILE=1 -o offline-libjsqrl.js
 echo "QRLLIB=Module;" >> web-libjsqrl.js
+echo "QRLLIB=Module;" >> offline-libjsqrl.js
 
 # Fix paths of web-libjsqrl.wasm for web clients
 sed -i 's/web-libjsqrl\.wasm/\/web-libjsqrl\.wasm/g' web-libjsqrl.js

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2017 The Quantum Resistant Ledger
+Copyright (c) 2019 The Quantum Resistant Ledger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This is necessary to run webassembly in a browser environment without the presence of a server (e.g. for simple offline wallet generation).