### PR TITLE
Fix googletest failing to build

### DIFF
--- a/CMakeLists.txt.gtest.in
+++ b/CMakeLists.txt.gtest.in
@@ -6,7 +6,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
         GIT_REPOSITORY    https://github.com/google/googletest.git
-        GIT_TAG           master
+        GIT_TAG           main
         SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
         BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
         CONFIGURE_COMMAND ""


### PR DESCRIPTION
Googletest was failing to build because the repository changed the primary branch from 'master' to 'main'. 

Fixed by changing git tag to reference main instead of master.