### PR TITLE
nit: Make XmssPool thread-safe and guard isAvailable()

### DIFF
--- a/src/qrl/xmssPool.cpp
+++ b/src/qrl/xmssPool.cpp
@@ -12,6 +12,7 @@ XmssPool::XmssPool(const TSEED &base_seed, uint8_t height, const size_t starting
         _height(height),
         _current_index(starting_index),
         _pool_size(pool_size) {
+    // No lock needed: the instance is not observable by another thread yet.
     fillCache();
 }
 
@@ -27,20 +28,46 @@ void XmssPool::fillCache() {
 }
 
 std::shared_ptr<XmssFast> XmssPool::getNextTree() {
-    if (_cache.empty()) {
-        return prepareTree(_current_index++);
+    std::future<std::shared_ptr<XmssFast>> pending;
+    size_t index = 0;
+    bool cache_missed = false;
+
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (_cache.empty()) {
+            // Claim the index under the lock; build the tree outside it.
+            index = _current_index++;
+            cache_missed = true;
+        } else {
+            // Move the future out so that the wait below happens outside the
+            // critical section. Leaving it in the deque and calling get() here
+            // would both serialise every caller behind key generation and allow
+            // a second caller to get() an already-consumed future.
+            pending = std::move(_cache.front());
+            _cache.pop_front();
+            _current_index++;
+
+            fillCache();
+        }
     }
 
-    auto answer = _cache.front().get();
-    _cache.pop_front();
-    _current_index++;
+    if (cache_missed) {
+        return prepareTree(index);
+    }
 
-    fillCache();
-
-    return answer;
+    return pending.get();
 }
 
 bool XmssPool::isAvailable() {
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    // front() is undefined on an empty deque, and _cache is always empty when
+    // _pool_size is 0.
+    if (_cache.empty()) {
+        return false;
+    }
+
     return _cache.front().wait_for(std::chrono::seconds(0)) == std::future_status::ready;
 }
 

--- a/src/qrl/xmssPool.h
+++ b/src/qrl/xmssPool.h
@@ -8,10 +8,20 @@
 #include <future>
 #include <deque>
 #include <memory>
+#include <mutex>
 #include "xmssBase.h"
 #include "xmssFast.h"
 
 // TODO: Add a namespace
+
+// Pre-computes XMSS trees on background threads so that getNextTree() can hand
+// one over without paying the key-generation cost inline.
+//
+// Every index is issued exactly once. XMSS is a stateful one-time signature
+// scheme, so handing the same index to two callers would let them sign two
+// different messages under the same WOTS+ key. All shared state is therefore
+// guarded by _mutex, and the public methods below are safe to call concurrently
+// on a single instance.
 class XmssPool {
 public:
     XmssPool(const TSEED &base_seed,
@@ -26,6 +36,7 @@ public:
     bool isAvailable();
 
     size_t getCurrentIndex() {
+        std::lock_guard<std::mutex> lock(_mutex);
         return _current_index;
     }
 
@@ -35,9 +46,13 @@ private:
     size_t _current_index;
     size_t _pool_size;
     std::deque<std::future<std::shared_ptr<XmssFast>>> _cache;
+    std::mutex _mutex;
 
+    // Caller must hold _mutex.
     void fillCache();
 
+    // Derives a tree from _base_seed and _height, both immutable after
+    // construction, so this is safe to call concurrently and without the lock.
     std::shared_ptr<XmssFast> prepareTree(size_t index);
 };
 

--- a/tests/cpp/qrl/xmssPool_test.cpp
+++ b/tests/cpp/qrl/xmssPool_test.cpp
@@ -2,7 +2,11 @@
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 #include <xmss-alt/algsxmss.h>
 #include <xmssBasic.h>
+#include <atomic>
 #include <iostream>
+#include <set>
+#include <thread>
+#include <vector>
 #include "gtest/gtest.h"
 #include <misc.h>
 #include <xmssPool.h>
@@ -69,5 +73,80 @@ namespace {
             auto xmss = pool.getNextTree();
             EXPECT_EQ(pks[i], bin2hstr(xmss->getPK()));
         }
+    }
+
+    // isAvailable() used to call _cache.front() with no empty() guard, which is
+    // undefined behaviour and crashed in practice. _cache is always empty when
+    // pool_size is 0, so this reached a public method with no threads involved.
+    TEST(XmssPool, IsAvailableOnEmptyCache) {
+        std::vector<unsigned char> seed(48, 0);
+
+        XmssPool pool(seed, 4, 0, 0);
+
+        EXPECT_FALSE(pool.isAvailable());
+    }
+
+    TEST(XmssPool, IsAvailableWithPrecomputedTrees) {
+        std::vector<unsigned char> seed(48, 0);
+
+        XmssPool pool(seed, 4, 0, 2);
+        pool.getNextTree();
+
+        // Drains the cache one tree at a time; isAvailable() must stay callable
+        // throughout rather than depending on the cache being non-empty.
+        EXPECT_NO_THROW(pool.isAvailable());
+    }
+
+    // XMSS is a stateful one-time signature scheme, so an index must never be
+    // issued twice: two callers holding the same index can sign two different
+    // messages under the same WOTS+ key. Unsynchronised _current_index++ and
+    // deque access allowed exactly that.
+    void expectEveryIndexIssuedOnce(size_t pool_size) {
+        const int thread_count = 8;
+
+        for (int attempt = 0; attempt < 20; attempt++) {
+            std::vector<unsigned char> seed(48, 0x42);
+            XmssPool pool(seed, 4, 0, pool_size);
+
+            std::vector<std::string> collected(thread_count);
+            std::vector<std::thread> threads;
+            std::atomic<bool> go(false);
+
+            for (int i = 0; i < thread_count; i++) {
+                threads.emplace_back([&pool, &collected, &go, i] {
+                    while (!go.load(std::memory_order_acquire)) {
+                        std::this_thread::yield();
+                    }
+                    collected[i] = bin2hstr(pool.getNextTree()->getPK());
+                });
+            }
+
+            // Release the threads together. Letting them start as they are
+            // spawned staggers them enough to hide the race.
+            go.store(true, std::memory_order_release);
+
+            for (auto &t : threads) {
+                t.join();
+            }
+
+            std::set<std::string> distinct(collected.begin(), collected.end());
+            ASSERT_EQ(distinct.size(), static_cast<size_t>(thread_count))
+                << "duplicate tree issued at pool_size=" << pool_size
+                << " on attempt " << attempt;
+            ASSERT_EQ(pool.getCurrentIndex(), static_cast<size_t>(thread_count));
+        }
+    }
+
+    TEST(XmssPool, ConcurrentGetNextTreeIsUniqueWithoutCache) {
+        // pool_size 0 exercises the prepareTree(_current_index++) branch, where
+        // a lost increment used to hand two threads the same index.
+        expectEveryIndexIssuedOnce(0);
+    }
+
+    TEST(XmssPool, ConcurrentGetNextTreeIsUniqueWithCache) {
+        // pool_size 2 exercises the cached branch, where two threads could
+        // get() the same future. That is undefined behaviour, not a duplicate,
+        // and it crashed rather than returning.
+        expectEveryIndexIssuedOnce(2);
     }
 }


### PR DESCRIPTION
Guard the shared cache and index with a mutex so each XMSS index is issued exactly once, and return false from isAvailable() when nothing has been pre-computed rather than calling front() on an empty deque.