### PR TITLE
fix: newer emscripten caveats

### DIFF
--- a/.circleci/build_emscripten.sh
+++ b/.circleci/build_emscripten.sh
@@ -4,7 +4,11 @@ emcmake cmake -DBUILD_WEBASSEMBLY=ON -DCMAKE_BUILD_TYPE=Release
 emmake make
 
 # Build with modern emscripten (include wrapper object files)
-emcc --bind CMakeFiles/jsqrl.dir/src/jswrapper/jsqrlwrapper.cpp.o libjsqrl.a libqrllib.a libshasha.a -s DISABLE_EXCEPTION_CATCHING=0 -O3 -o libjsqrl.js
+# libjsqrl.js must be self-contained: package.json only publishes the .js, and
+# modern emscripten defaults to WASM=1 with an external .wasm sidecar. SINGLE_FILE
+# embeds the wasm so the published module loads standalone (as the old asm.js
+# default output did) under node, browsers and bundlers alike.
+emcc --bind CMakeFiles/jsqrl.dir/src/jswrapper/jsqrlwrapper.cpp.o libjsqrl.a libqrllib.a libshasha.a -s DISABLE_EXCEPTION_CATCHING=0 -O3 -s WASM=1 -s SINGLE_FILE=1 -o libjsqrl.js
 emcc --bind CMakeFiles/jsqrl.dir/src/jswrapper/jsqrlwrapper.cpp.o libjsqrl.a libqrllib.a libshasha.a -s DISABLE_EXCEPTION_CATCHING=0 -O3 -s WASM=1 -o web-libjsqrl.js
 emcc --bind CMakeFiles/jsqrl.dir/src/jswrapper/jsqrlwrapper.cpp.o libjsqrl.a libqrllib.a libshasha.a -s DISABLE_EXCEPTION_CATCHING=0 -O3 -s WASM=1 -s SINGLE_FILE=1 -o offline-libjsqrl.js
 emcc --bind CMakeFiles/jsdilithium.dir/src/jswrapper/jsdilwrapper.cpp.o libjsdilithium.a libdilithium.a libshasha.a -s DISABLE_EXCEPTION_CATCHING=0 -O3 -s WASM=1 -s SINGLE_FILE=1 -o offline-libjsdilithium.js

--- a/tests/js/tests/qrllib.spec.js
+++ b/tests/js/tests/qrllib.spec.js
@@ -13,16 +13,10 @@ test.describe('libjsqrl browser tests', () => {
         // Visit the test HTML page that loads the library
         await page.goto('/tests/js/test.html');
 
-        // Wait for the library to be loaded and initialized
-        await page.waitForFunction(() => window.libqrl !== null && window.libqrl !== undefined);
-
-        // Ensure the WASM module is ready
-        await page.waitForFunction(() => {
-            if (window.libqrl.calledRun) {
-                return true;
-            }
-            return false;
-        }, { timeout: 30000 });
+        // Wait for the library to be loaded and initialized. test.html sets
+        // libqrlReady once the runtime is up; Module.calledRun is not exposed by
+        // newer emscripten releases, so it cannot be used as the ready signal.
+        await page.waitForFunction(() => window.libqrlReady === true, { timeout: 30000 });
 
         // Get libqrl reference for the test
         libqrl = await page.evaluate(() => window.libqrl);


### PR DESCRIPTION
This pull request improves the build process for the `libjsqrl.js` WebAssembly module and updates the browser test initialization logic to support newer Emscripten releases. The main changes ensure that the published JavaScript module is fully self-contained and that tests reliably detect when the library is ready, even with modern Emscripten builds.

**Build process improvements:**

* Updated the `emcc` command in `.circleci/build_emscripten.sh` to add `-s WASM=1 -s SINGLE_FILE=1` for `libjsqrl.js`, ensuring the output is a single, self-contained JavaScript file with the WebAssembly binary embedded. This allows the published module to work standalone across different environments without requiring an external `.wasm` file.

**Test initialization updates:**

* Modified the browser test in `qrllib.spec.js` to wait for a new `window.libqrlReady` flag instead of relying on `Module.calledRun`, which is no longer exposed by recent Emscripten versions. This ensures tests reliably wait for the runtime to be ready.